### PR TITLE
Fixing None return on

### DIFF
--- a/lars/apache.py
+++ b/lars/apache.py
@@ -341,8 +341,7 @@ def _generate_name(template, data, suffix):
                     }[data]
             except KeyError:
                 raise ValueError('Invalid format in "%%{%s}P"' % data)
-    else:
-        return template
+    return template
 
 
 class ApacheError(LarsError):


### PR DESCRIPTION
While inquiring the error below, I though `_generate_name` behavior wasn't the one intended.
```
>>> apache.ApacheSource(['app.jarr.info:443 192.99.37.47 - - [24/Jan/2023:14:39:41 +0100] "GET / HTTP/2.0" 200 1245 "-" "updown.io daemon 2.9"'], '%v %p %h %l %u %t "%r" %>s %O "%{Referer}i" "%{User-Agent}i"')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/jaes/.cache/pypoetry/virtualenvs/papache-log-parser-hFQMj0L_-py3.10/lib/python3.10/site-packages/lars/apache.py", line 469, in __init__
    self._parse_log_format()
  File "/home/jaes/.cache/pypoetry/virtualenvs/papache-log-parser-hFQMj0L_-py3.10/lib/python3.10/site-packages/lars/apache.py", line 617, in _parse_log_format
    ','.join(tuple_fields))
TypeError: sequence item 1: expected str instance, NoneType found
```